### PR TITLE
Clean local interface link from Binder

### DIFF
--- a/actors-library/src/main/java/com/truecaller/androidactors/ActorService.java
+++ b/actors-library/src/main/java/com/truecaller/androidactors/ActorService.java
@@ -140,6 +140,10 @@ public class ActorService extends Service {
     public void onDestroy() {
         super.onDestroy();
 
+        final Binder binder = mBinder;
+        if (binder != null) {
+            binder.attachInterface(null, null);
+        }
         mThread.quit();
     }
 


### PR DESCRIPTION
Binder has finalize() method and it takes significant time to destroy
it. We should clean all references to our helper classes for making them
collectable by GC before it happens.