### PR TITLE
Remove library version from README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Android Actors Library was inspired by the [Actor model](https://en.wikipedia.or
 Add the following dependencies to your project:
 
 ```groovy
-compile group: 'com.truecaller', name: 'android-actors-library', version: '1.1.5'
-annotationProcessor group:'com.truecaller', name: 'android-actors-generator', version: '1.1.5'
+compile group: 'com.truecaller', name: 'android-actors-library', version: <LATEST-VERSION>
+annotationProcessor group:'com.truecaller', name: 'android-actors-generator', version: <LATEST-VERSION>
 ```
 
 #### Specify a package for ActorsBuilder


### PR DESCRIPTION
We have the library verison as a badge on top of README file. It updates itself by data from Maven Central. I am sure that one time we will forget to update a version in build config example, so it is better to force developers to specify a verion them selves.