### PR TITLE
Do not share UI thread between different instances of ActorThreads

### DIFF
--- a/actors-library/src/main/java/com/truecaller/androidactors/ActorsThreadsBase.java
+++ b/actors-library/src/main/java/com/truecaller/androidactors/ActorsThreadsBase.java
@@ -40,7 +40,7 @@ public abstract class ActorsThreadsBase implements ActorsThreads {
     private final FailureHandler mFailureHandler;
 
     @Nullable
-    private static volatile ActorThread sUiThread = null;
+    private volatile ActorThread mUiThread = null;
 
     public ActorsThreadsBase(@NonNull ProxyFactory proxyFactory) {
         this(proxyFactory, new CrashEarlyFailureHandler());
@@ -53,12 +53,12 @@ public abstract class ActorsThreadsBase implements ActorsThreads {
 
     @NonNull
     public ActorThread ui() {
-        ActorThread thread = sUiThread;
+        ActorThread thread = mUiThread;
         if (thread == null) {
-            synchronized (ActorsThreadsBase.class) {
-                if ((thread = sUiThread) == null) {
+            synchronized (mProxyFactory) {
+                if ((thread = mUiThread) == null) {
                     thread = createThread(Looper.getMainLooper());
-                    sUiThread = thread;
+                    mUiThread = thread;
                 }
             }
         }


### PR DESCRIPTION
ActorThread instance depends on ProxyFactory which will be different for
different ActorThreads instances