### PR TITLE
Handle job cancellation on actor services

### DIFF
--- a/actors-library/src/main/java/com/truecaller/androidactors/ActorService.java
+++ b/actors-library/src/main/java/com/truecaller/androidactors/ActorService.java
@@ -205,6 +205,9 @@ public class ActorService extends Service {
 
         @Override
         protected void stopThread() {
+            if (mJobEngine != null) {
+                mJobEngine.reportServerStop();
+            }
             stopSelf();
         }
     }

--- a/actors-library/src/main/java/com/truecaller/androidactors/JobSchedulerHelper.java
+++ b/actors-library/src/main/java/com/truecaller/androidactors/JobSchedulerHelper.java
@@ -46,6 +46,13 @@ public abstract class JobSchedulerHelper {
         scheduler.schedule(job);
     }
 
+    public static void cancelJob(@NonNull Context context, int id) {
+        JobScheduler scheduler = (JobScheduler) context.getSystemService(Context.JOB_SCHEDULER_SERVICE);
+        if (scheduler != null) {
+            scheduler.cancel(id);
+        }
+    }
+
     @NonNull
     public static ActorService.ActorJobEngine createJobEngine(@NonNull Service service, @NonNull Callable<IBinder> binder) {
         return new ActorJobServiceEngine(service, binder);


### PR DESCRIPTION
* When service is scheduled instead of starting and binding directly,
IllegalArgumentException is thrown when it is needed to be unbound.
Check if service is bound before unbinding.

* Call 'jobFinished' to stop scheduled job services.